### PR TITLE
Prepublish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "compile": "gulp compile",
     "test": "gulp test",
+    "prepublish": "gulp compile",
     "2npm": "publish"
   },
   "repository": {


### PR DESCRIPTION
The dist folder is not being published , so installing the npm package will not work correctly as the main file doesn't exist.

