### PR TITLE
0.2.0 support for bucket passwords

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -16,7 +16,10 @@ if (!config.couchbase || !config.couchbase.migrationBucket) {
 const host = `couchbase://${process.env.COUCHBASE_PORT_8091_TCP_ADDR}:${process.env.COUCHBASE_PORT_8091_TCP_PORT}?detailed_errcodes=1`;
 console.log(`Connecting to ${host}, opening bucket ${config.couchbase.migrationBucket}`);
 const cluster = new couchbase.Cluster(host);
-const bucket = cluster.openBucket(config.couchbase.migrationBucket);
+const bucketPassword = config.bucketPassword;
+const bucket = (bucketPassword ?
+  cluster.openBucket(config.couchbase.migrationBucket, bucketPassword) :
+  cluster.openBucket(config.couchbase.migrationBucket));
 
 export default {
   cluster, bucket,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-migrate-couchbase",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "db-migrate plugin for couchbase",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
If a couchbase bucket is secured by a password, it is possible to add a `bucketPassword` option to the configuration.   Whenever couch node's `openBucket` function is called, it's called with the bucket password so you can migrate data in password-protected buckets.   The `bucketPassword` does not have to match the regular username/password.