### PR TITLE
Upgrade ottoman

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "uuid": "^2.0.2"
   },
   "optionalDependencies": {
-    "ottoman": "git+https://github.com/couchbaselabs/node-ottoman.git#9f9262ccb0286c3ddbc72ae478b0a84db6aa5964",
-    "couchbase": "2.2.4"
+    "ottoman": "git+https://github.com/etops/node-ottoman.git#5b80b9312674e2c56a7cecb5b9f38725e56381b7",
+    "couchbase": "2.2.5"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-migrate-couchbase",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "db-migrate plugin for couchbase",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "author": "David Allen <d.allen@etops.ch>",
   "license": "MIT",
   "dependencies": {
+    "ottoman": "git+https://github.com/etops/node-ottoman.git#5b80b9312674e2c56a7cecb5b9f38725e56381b7",
+    "couchbase": "2.2.5",
     "bluebird": "^3.4.1",
     "bunyan": "^1.8.1",
     "bunyan-prettystream": "^0.1.3",
@@ -27,10 +29,6 @@
     "publish": "^0.6.0",
     "randomstring": "^1.1.5",
     "uuid": "^2.0.2"
-  },
-  "optionalDependencies": {
-    "ottoman": "git+https://github.com/etops/node-ottoman.git#5b80b9312674e2c56a7cecb5b9f38725e56381b7",
-    "couchbase": "2.2.5"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
   "author": "David Allen <d.allen@etops.ch>",
   "license": "MIT",
   "dependencies": {
-    "ottoman": "git+https://github.com/etops/node-ottoman.git#5b80b9312674e2c56a7cecb5b9f38725e56381b7",
-    "couchbase": "2.2.5",
     "bluebird": "^3.4.1",
     "bunyan": "^1.8.1",
     "bunyan-prettystream": "^0.1.3",
@@ -29,6 +27,10 @@
     "publish": "^0.6.0",
     "randomstring": "^1.1.5",
     "uuid": "^2.0.2"
+  },
+  "optionalDependencies": {
+    "ottoman": "git+https://github.com/etops/node-ottoman.git#5b80b9312674e2c56a7cecb5b9f38725e56381b7",
+    "couchbase": "2.3.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
upgrade is needed because of version conflict on ow-back branch with ottoman version with fixed namespace bugs